### PR TITLE
emulator camera for gesture recorder

### DIFF
--- a/tools/ReFlex.TrackingServer/Model/CameraManager.cs
+++ b/tools/ReFlex.TrackingServer/Model/CameraManager.cs
@@ -38,7 +38,7 @@ namespace TrackingServer.Model
             {
                 Logger.Error(exception);
             }
-            
+
             try
             {
                 var realSenseD435 = new RealsenseD435Camera();
@@ -101,6 +101,12 @@ namespace TrackingServer.Model
                 // var emulator = new EmulatorCamera();
                 _depthCameras.Add(emulator);
                 Logger.Info($"Successfully loaded {emulator.ModelDescription} camera.");
+
+                var gestureRecorder = new EmulatorCamera("127.0.0.1", 30000, "/Recorder");
+                _depthCameras.Add(gestureRecorder);
+
+                Logger.Info($"Successfully loaded {gestureRecorder.ModelDescription} camera.");
+
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
added a second emulator camera for use with gesture recorder
websocket address is: localhost:3000/Recorder

![image](https://github.com/joelderG/reflex-projektseminar/assets/5312222/6557f32d-ee74-4c27-8f86-6e07e395520d)
